### PR TITLE
keep old scissor

### DIFF
--- a/gamera.lua
+++ b/gamera.lua
@@ -1,6 +1,6 @@
 -- gamera.lua v1.0.1
 
--- Copyright (c) 2012 Enrique García Cota
+-- Copyright (c) 2018 Enrique García Cota
 -- Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 -- The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 -- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
@@ -170,6 +170,7 @@ function gamera:getVisibleCorners()
 end
 
 function gamera:draw(f)
+  local sx, sy, sw, sh = love.graphics.getScissor()
   love.graphics.setScissor(self:getWindow())
 
   love.graphics.push()
@@ -184,7 +185,7 @@ function gamera:draw(f)
 
   love.graphics.pop()
 
-  love.graphics.setScissor()
+  love.graphics.setScissor(sx, sy, sw, sh)
 end
 
 function gamera:toWorld(x,y)


### PR DESCRIPTION
Other libraries might use scissors. In its current state, gamera will conflict with them. Let's revert back to the old scissor once we're done drawing the camera.